### PR TITLE
Update `go.mod`/`go.sum` with indirect dependencies.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/mattn/go-runewidth v0.0.9
 	github.com/riywo/loginshell v0.0.0-20190610082906-2ed199a032f6
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,4 +24,6 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 h1:XfKQ4OlFl8okEOr5UvAqFRVj8pY/4yfcXrddB8qAbU0=
+golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Hi,

First off thanks for writing this tool. I've gotten some good use out of it.

I've just submitted a PR to [nixpkgs](https://github.com/NixOS/nixpkgs) to add `ets` to their package repository. One thing I did to achieve a build within the nix sandbox (no internet access during build) was a patch to `go.mod` and `go.sum` to make it so all dependencies could be easily pulled into the build sandbox.

I'm not very familiar with standard go workflows so I was unsure if this was something you kept excluded from these files intentionally or not. If they're excluded intentionally or there's a benefit to not adding them feel free to ignore this PR, otherwise it'd be great if these could be updated here, after which I could remove the patch on nixpkgs.